### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -104,7 +104,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -170,7 +170,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -236,7 +236,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -294,7 +294,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -313,7 +313,7 @@ jobs:
       - name: Prepare outputs for caching
         run: mv build/bundle $OS-$TARGET
       - name: Cache outputs for universal build
-        uses: actions/cache/save@v4.1.2
+        uses: actions/cache/save@v4.2.0
         with:
           path: ${{ env.OS }}-${{ env.TARGET }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -326,13 +326,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4.2.2
       - name: Download x86_64 build from cache
-        uses: actions/cache/restore@v4.1.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ${{ env.OS }}-x86_64
           key: ${{ runner.os }}-x86_64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
       - name: Download ARM64 build from cache
-        uses: actions/cache/restore@v4.1.2
+        uses: actions/cache/restore@v4.2.0
         with:
           path: ${{ env.OS }}-arm64
           key: ${{ runner.os }}-arm64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -367,7 +367,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -443,7 +443,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: |
             ~/.gradle/caches
@@ -468,7 +468,7 @@ jobs:
           cmakeVersion: latest
           ninjaVersion: latest
       - name: Install JDK 23
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.5.0
         with:
           distribution: 'temurin'
           java-version: '23'
@@ -505,7 +505,7 @@ jobs:
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4.1.2
+        uses: actions/cache@v4.2.0
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-ios-${{ github.sha }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.0](https://github.com/actions/cache/releases/tag/v4.2.0)** on 2024-12-05T16:45:49Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.5.0](https://github.com/actions/setup-java/releases/tag/v4.5.0)** on 2024-10-24T13:59:09Z
