### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,18 +24,18 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1.13.0
         if: ${{ matrix.target == 'msvc' }}
       - name: Install extra tools (MSVC)
         run: choco install ccache ninja wget unzip
@@ -46,7 +46,7 @@ jobs:
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
@@ -65,18 +65,18 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Set up MSYS2 (clang)
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.27.0
         if: ${{ matrix.target == 'clang' }}
         with:
           msystem: clang64
@@ -93,7 +93,7 @@ jobs:
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
@@ -112,18 +112,18 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Set up MINGW (gcc)
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.27.0
         with:
           msystem: mingw64
           update: true
@@ -146,7 +146,7 @@ jobs:
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
@@ -159,11 +159,11 @@ jobs:
       OS: android
       TARGET: universal
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.2
         with:
           path: |
             ~/.gradle/caches
@@ -183,12 +183,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install zip unzip python3 ccache apksigner && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v3.31.6
         with:
           cmakeVersion: 3.30.6
           ninjaVersion: latest
       - name: Install JDK 23
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.7.0
         with:
           distribution: 'temurin'
           java-version: '23'
@@ -207,7 +207,7 @@ jobs:
         env:
           UNPACKED: 1
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.1
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: src/android/app/artifacts/

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear cache
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             console.log("About to clear")

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Install Clang PPA

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.UPDATEACTIONS }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[lukka/get-cmake](https://github.com/lukka/get-cmake)** published a new release **[v3.31.6](https://github.com/lukka/get-cmake/releases/tag/v3.31.6)** on 2025-02-25T17:49:53Z
* **[msys2/setup-msys2](https://github.com/msys2/setup-msys2)** published a new release **[v2.27.0](https://github.com/msys2/setup-msys2/releases/tag/v2.27.0)** on 2025-02-22T14:15:03Z
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.0](https://github.com/actions/setup-java/releases/tag/v4.7.0)** on 2025-01-29T03:24:46Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)** on 2025-02-21T19:00:26Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** on 2023-11-17T22:21:53Z
* **[ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd)** published a new release **[v1.13.0](https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0)** on 2024-01-01T04:32:14Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.2](https://github.com/actions/cache/releases/tag/v4.2.2)** on 2025-02-27T14:49:12Z
