### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,13 +13,13 @@ jobs:
     if: ${{ !github.head_ref }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Pack
         run: ./.ci/source.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: source
           path: artifacts/
@@ -35,11 +35,11 @@ jobs:
       OS: linux
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -60,12 +60,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install gcc-13-base ccache clang-19 clang-19-doc clang-format-19 clang-tidy-19 clang-tools-19 clangd-19 cpp-13 fonts-mathjax g++-13 gcc-13 jackd jackd2 jackd2-firewire libasan8 libasound2-dev libasyncns0 libaudio-dev libaudio2 libc++-19-dev libc++1-19 libc++abi-19-dev libc++abi1-19 libclang-19-dev libclang-common-19-dev libclang-cpp19 libclang-rt-19-dev libclang1-19 libconfig++9v5 libdmx-dev libdmx1 libdouble-conversion3 libdrm-dev libegl-mesa0 libegl1 libevdev2 libffado2 libflac8 libfontenc-dev libfs-dev libfs6 libgcc-13-dev libgl-dev libglibmm-2.4-1v5 libglx-dev libhwasan0 libiec61883-0 libinput-bin libinput10 libjack-jackd2-0 libjs-mathjax libllvm19 libmtdev1 libpciaccess-dev libpipewire-0.2-1 libpipewire-0.2-dev libpulse-dev libpulse-mainloop-glib0 libpulse0 libqt5core5a libqt5dbus5 libqt5gui5 libqt5network5 libqt5svg5 libqt5widgets5 libqt5x11extras5 libqt5xml5 libraw1394-11 libsamplerate0 libsigc++-2.0-0v5 libsndfile1 libsndio-dev libsndio7.0 libspa-lib-0.1-dev libstdc++-13-dev libtsan2 libunwind-19 libunwind-19-dev libvorbisenc2 libwacom-bin libwacom-common libwacom2 libxaw7-dev libxcb-cursor-dev libxcb-cursor0 libxcb-icccm4 libxcb-image0 libxcb-image0-dev libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-render-util0-dev libxcb-shape0 libxcb-util1 libxcb-xinerama0 libxcb-xinput0 libxcb-xkb-dev libxcb-xkb1 libxcomposite-dev libxcursor-dev libxdamage-dev libxfixes-dev libxfont-dev libxi-dev libxinerama-dev libxkbcommon-x11-0 libxml++2.6-2v5 libxmu-dev libxmu-headers libxmuu-dev libxpm-dev libxrandr-dev libxres-dev libxres1 libxss-dev libxtst-dev libxv-dev libxv1 libxvmc-dev libxvmc1 libxxf86dga-dev libxxf86dga1 libxxf86vm-dev llvm-19 llvm-19-dev llvm-19-linker-tools llvm-19-runtime llvm-19-tools mesa-common-dev python-dbus python-gi python3-clang-19 qjackctl x11proto-input-dev x11proto-randr-dev x11proto-record-dev x11proto-scrnsaver-dev x11proto-xf86dga-dev x11proto-xf86vidmode-dev x11proto-xinerama-dev xorg-dev xserver-xorg-dev gstreamer1.0-gl gstreamer1.0-plugins-base libcdparanoia0 libegl-dev libgl1-mesa-dev libgles-dev libgles1 libgles2 libglvnd-dev libgraphene-1.0-0 libgstreamer-gl1.0-0 libgstreamer-plugins-base1.0-0 libopengl-dev libopengl0 libopus0 liborc-0.4-0 libtheora0 libvisual-0.4-0 libxkbcommon-dev unzip && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.1
         with:
           cmakeVersion: latest
           ninjaVersion: latest
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.2.1
         with:
           aqtversion: '==3.2.*'
           version: '6.8.2'
@@ -84,7 +84,7 @@ jobs:
         run: ./.ci/pack.sh
         if: ${{ matrix.target == 'appimage-clang-20.04' }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: ${{ matrix.target == 'appimage-clang-20.04' }}
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
@@ -101,11 +101,11 @@ jobs:
       OS: linux
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -126,12 +126,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install ccache gcc-11 clang-20 clang-tools-20 clang-20-doc libxcb-xkb-dev libclang-common-20-dev libclang-20-dev libclang1-20 clang-format-20 python3-clang-20 clangd-20 clang-tidy-20 libasound-dev xorg-dev libx11-dev libxext-dev jackd libpipewire-0.3-dev libsndio-dev libxcb-cursor-dev libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev unzip && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.1
         with:
           cmakeVersion: latest
           ninjaVersion: latest
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.2.1
         with:
           aqtversion: '==3.2.*'
           version: '6.8.2'
@@ -150,7 +150,7 @@ jobs:
         run: ./.ci/pack.sh
         if: ${{ matrix.target == 'appimage-clang-22.04' }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: ${{ matrix.target == 'appimage-clang-22.04' }}
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
@@ -167,11 +167,11 @@ jobs:
       OS: linux
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -192,12 +192,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install ccache gcc-14 clang-20 clang-tools-20 clang-20-doc libxcb-xkb-dev libclang-common-20-dev libclang-20-dev libclang1-20 clang-format-20 python3-clang-20 clangd-20 clang-tidy-20 libasound-dev xorg-dev libx11-dev libxext-dev jackd libpipewire-0.3-dev libsndio-dev libxcb-cursor-dev libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev unzip && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.1
         with:
           cmakeVersion: latest
           ninjaVersion: latest
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.2.1
         with:
           aqtversion: '==3.2.*'
           version: '6.8.2'
@@ -216,7 +216,7 @@ jobs:
         run: ./.ci/pack.sh
         if: ${{ matrix.target == 'appimage-clang-24.04' }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: ${{ matrix.target == 'appimage-clang-24.04' }}
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
@@ -233,11 +233,11 @@ jobs:
       OS: linux
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
@@ -250,12 +250,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install ccache gcc-14 build-essential libxcb-xkb-dev libasound-dev xorg-dev libx11-dev libxext-dev jackd libpipewire-0.3-dev libsndio-dev libxcb-cursor-dev libasound2-dev libpulse-dev libaudio-dev libjack-dev libsndio-dev libx11-dev libxext-dev libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev libwayland-dev libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev unzip && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.1
         with:
           cmakeVersion: latest
           ninjaVersion: latest
       - name: Install Qt
-        uses: jurplel/install-qt-action@v4
+        uses: jurplel/install-qt-action@v4.2.1
         with:
           aqtversion: '==3.2.*'
           version: '6.8.2'
@@ -274,7 +274,7 @@ jobs:
         run: ./.ci/pack.sh
         if: ${{ matrix.target == 'appimage-gcc-24.04' }}
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         if: ${{ matrix.target == 'appimage-gcc-24.04' }}
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
@@ -291,22 +291,22 @@ jobs:
       OS: macos
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: latest-stable
       - name: Install tools
-        uses: tecolicom/actions-use-homebrew-tools@v1
+        uses: tecolicom/actions-use-homebrew-tools@v1.3
         with:
           tools: ccache ninja
       - name: Build
@@ -314,7 +314,7 @@ jobs:
       - name: Prepare outputs for caching
         run: mv build/bundle $OS-$TARGET
       - name: Cache outputs for universal build
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v4.2.3
         with:
           path: ${{ env.OS }}-${{ env.TARGET }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -325,15 +325,15 @@ jobs:
       OS: macos
       TARGET: universal
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
       - name: Download x86_64 build from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v4.2.3
         with:
           path: ${{ env.OS }}-x86_64
           key: ${{ runner.os }}-x86_64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
           fail-on-cache-miss: true
       - name: Download ARM64 build from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v4.2.3
         with:
           path: ${{ env.OS }}-arm64
           key: ${{ runner.os }}-arm64-${{ github.sha }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -345,7 +345,7 @@ jobs:
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
@@ -364,24 +364,24 @@ jobs:
       OS: windows
       TARGET: ${{ matrix.target }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-${{ matrix.target }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.target }}-
       - name: Set up MSVC
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@v1.13.0
         if: ${{ matrix.target == 'msvc' }}
       - name: Install extra tools (MSVC)
         run: choco install ccache ninja wget unzip
         if: ${{ matrix.target == 'msvc' }}
       - name: Set up MSYS2 (clang)
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.27.0
         if: ${{ matrix.target == 'clang' }}
         with:
           msystem: clang64
@@ -391,7 +391,7 @@ jobs:
             toolchain:p ccache:p cmake:p ninja:p 
             qt6-base:p qt6-multimedia:p qt6-multimedia-wmf:p qt6-tools:p qt6-translations:p
       - name: Set up MINGW (gcc)
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@v2.27.0
         with:
           msystem: mingw64
           update: true
@@ -427,7 +427,7 @@ jobs:
       - name: Pack
         run: ./.ci/pack.sh
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: artifacts/
@@ -440,11 +440,11 @@ jobs:
       OS: android
       TARGET: universal
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: |
             ~/.gradle/caches
@@ -464,12 +464,12 @@ jobs:
       - name: Install New Packages
         run: sudo apt-get -y install zip unzip python3 ccache apksigner && sudo apt-get clean
       - name: Get latest CMake and Ninja
-        uses: lukka/get-cmake@latest
+        uses: lukka/get-cmake@v4.0.1
         with:
           cmakeVersion: 3.30.6
           ninjaVersion: latest
       - name: Install JDK 23
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v4.7.1
         with:
           distribution: 'temurin'
           java-version: '23'
@@ -488,7 +488,7 @@ jobs:
         env:
           UNPACKED: 1
       - name: Upload
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: ${{ env.OS }}-${{ env.TARGET }}
           path: src/android/app/artifacts/
@@ -502,22 +502,22 @@ jobs:
       OS: ios
       TARGET: arm64
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           submodules: recursive
       - name: Set up cache
-        uses: actions/cache@v4
+        uses: actions/cache@v4.2.3
         with:
           path: ${{ env.CCACHE_DIR }}
           key: ${{ runner.os }}-ios-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-ios-
       - name: Setup XCode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@v1.6.0
         with:
           xcode-version: latest-stable
       - name: Install tools
-        uses: tecolicom/actions-use-homebrew-tools@v1
+        uses: tecolicom/actions-use-homebrew-tools@v1.3
         with:
           tools: ccache ninja
       - name: Build
@@ -527,9 +527,9 @@ jobs:
     needs: [windows, linux-clang-focal, linux-clang-jammy, linux-clang-noble, linux-gcc-noble, macos-universal, android, source]
     if: ${{ startsWith(github.ref, 'refs/tags/') }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v4.3.0
       - name: Create release
-        uses: actions/create-release@v1
+        uses: actions/create-release@v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/clear-cache.yml
+++ b/.github/workflows/clear-cache.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clear cache
-        uses: actions/github-script@v7
+        uses: actions/github-script@v7.0.1
         with:
           script: |
             console.log("About to clear")

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -10,7 +10,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
       - name: Install Clang PPA

--- a/.github/workflows/update-actions.yml
+++ b/.github/workflows/update-actions.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.2.2
         with:
           # [Required] Access token with `workflow` scope.
           token: ${{ secrets.UPDATEACTIONS }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-java](https://github.com/actions/setup-java)** published a new release **[v4.7.1](https://github.com/actions/setup-java/releases/tag/v4.7.1)** on 2025-04-09T02:58:20Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
* **[tecolicom/actions-use-homebrew-tools](https://github.com/tecolicom/actions-use-homebrew-tools)** published a new release **[v1.3](https://github.com/tecolicom/actions-use-homebrew-tools/releases/tag/v1.3)** on 2024-08-19T10:08:39Z
* **[maxim-lobanov/setup-xcode](https://github.com/maxim-lobanov/setup-xcode)** published a new release **[v1.6.0](https://github.com/maxim-lobanov/setup-xcode/releases/tag/v1.6.0)** on 2023-09-23T13:54:01Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.3](https://github.com/actions/cache/releases/tag/v4.2.3)** on 2025-03-19T18:18:32Z
* **[ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd)** published a new release **[v1.13.0](https://github.com/ilammy/msvc-dev-cmd/releases/tag/v1.13.0)** on 2024-01-01T04:32:14Z
* **[actions/github-script](https://github.com/actions/github-script)** published a new release **[v7.0.1](https://github.com/actions/github-script/releases/tag/v7.0.1)** on 2023-11-17T22:21:53Z
* **[actions/create-release](https://github.com/actions/create-release)** published a new release **[v1.1.4](https://github.com/actions/create-release/releases/tag/v1.1.4)** on 2020-09-14T13:55:07Z
* **[msys2/setup-msys2](https://github.com/msys2/setup-msys2)** published a new release **[v2.27.0](https://github.com/msys2/setup-msys2/releases/tag/v2.27.0)** on 2025-02-22T14:15:03Z
* **[actions/download-artifact](https://github.com/actions/download-artifact)** published a new release **[v4.3.0](https://github.com/actions/download-artifact/releases/tag/v4.3.0)** on 2025-04-24T16:28:16Z
* **[actions/upload-artifact](https://github.com/actions/upload-artifact)** published a new release **[v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)** on 2025-03-19T17:47:02Z
* **[lukka/get-cmake](https://github.com/lukka/get-cmake)** published a new release **[v4.0.1](https://github.com/lukka/get-cmake/releases/tag/v4.0.1)** on 2025-04-11T07:17:38Z
* **[jurplel/install-qt-action](https://github.com/jurplel/install-qt-action)** published a new release **[v4.2.1](https://github.com/jurplel/install-qt-action/releases/tag/v4.2.1)** on 2025-04-21T16:31:18Z
